### PR TITLE
ci(workflows): configure CI/CD workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    versioning-strategy: "auto"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    reviewers:
+      - "ruslanpashkov"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: node:22
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TypeScript check
+        run: npm run compile
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Release
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: Browser targets
+        required: true
+        default: '["chrome","firefox"]'
+        type: choice
+        options:
+          - '["chrome","firefox"]'
+          - '["chrome"]'
+          - '["firefox"]'
+      attach_to_release:
+        description: Attach to GitHub release
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: node:20
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(github.event.inputs.targets || '["chrome","firefox"]') }}
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Build extension
+        run: |
+          npm ci
+          npm run zip -- -b ${{ matrix.target }}
+          npm audit
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ matrix.target }}
+          path: ./.output/novapass-*-${{ matrix.target }}.zip
+
+  publish-chrome:
+    needs: build
+    if: ${{ github.event_name == 'release' || contains(github.event.inputs.targets, 'chrome') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@main
+        with:
+          name: chrome
+
+      - name: Upload to GitHub Release
+        if: ${{ github.event_name == 'release' || github.event.inputs.attach_to_release == 'true' }}
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: novapass-*-chrome.zip
+          draft: false
+          overwrite: true
+          update_latest_release: true
+
+      - name: Publish to Chrome Web Store
+        uses: wdzeng/chrome-extension@v1.2.4
+        with:
+          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
+          zip-path: novapass-*-chrome.zip
+          client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
+
+  publish-edge:
+    needs: build
+    if: ${{ github.event_name == 'release' || contains(github.event.inputs.targets, 'chrome') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@main
+        with:
+          name: chrome
+
+      - name: Upload to GitHub Release
+        if: ${{ github.event_name == 'release' || github.event.inputs.attach_to_release == 'true' }}
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: novapass-*-chrome.zip
+          draft: false
+          overwrite: true
+          update_latest_release: true
+
+      - name: Publish to Edge Add-ons
+        uses: wdzeng/edge-addon@v2.0.0
+        with:
+          product-id: ${{ secrets.EDGE_PRODUCT_ID }}
+          zip-path: novapass-*-chrome.zip
+          client-id: ${{ secrets.EDGE_CLIENT_ID }}
+          api-key: ${{ secrets.EDGE_API_KEY }}
+
+  publish-firefox:
+    needs: build
+    if: ${{ github.event_name == 'release' || contains(github.event.inputs.targets, 'firefox') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@main
+        with:
+          name: firefox
+
+      - name: Upload to GitHub Release
+        if: ${{ github.event_name == 'release' || github.event.inputs.attach_to_release == 'true' }}
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: novapass-*-firefox.zip
+          draft: false
+          overwrite: true
+          update_latest_release: true
+
+      - name: Publish to Firefox Add-ons
+        uses: wdzeng/firefox-addon@v1.1.2
+        with:
+          addon-guid: ${{ secrets.FIREFOX_ADDON_GUID }}
+          xpi-path: novapass-*-firefox.zip
+          jwt-issuer: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          jwt-secret: ${{ secrets.FIREFOX_JWT_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: node:20
+    container: node:22
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Added GitHub Actions workflows for automated linting and release processes, along with Dependabot configuration for dependency management.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Tests
- [x] CI/CD

## Testing

1. Lint workflow triggers on PR to main branch and manual dispatch
2. Release workflow triggers on release publish and manual dispatch
3. Test both workflows by:
   - Creating a PR to verify lint checks
   - Creating a test release to verify build and publish steps

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Follows coding style guidelines
- [x] Commits follow conventional style

## Additional Notes

- Release workflow supports Chrome, Firefox and Edge browsers
- Requires adding necessary secrets for store publishing
- Dependabot configured for weekly updates on Mondays
- Node 22 used for release builds and linting